### PR TITLE
Fix compilation for disabled compression feature & Replay hitresult documentation fix

### DIFF
--- a/src/replay.rs
+++ b/src/replay.rs
@@ -342,7 +342,7 @@ fn write_replay_data<W: Write>(
     compression_level: u32,
 ) -> io::Result<()> {
     let mut raw = raw.as_deref();
-    let compress_buf;
+    let compress_buf: Vec<u8>;
     //Compress if it's enabled and available
     #[cfg(feature = "compression")]
     {

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -23,17 +23,17 @@ pub struct Replay {
     pub player_name: Option<String>,
     /// The replay-specific MD5 hash.
     pub replay_hash: Option<String>,
-    /// The same in all modes: amount of 300 scores.
+    /// Amount of 300s (fruits in ctb).
     pub count_300: u16,
-    /// Amount of 100 scores in std and ctb, but 150 in taiko and 200 in mania.
+    /// Amount of 100s (drops in ctb).
     pub count_100: u16,
-    /// Amount of 50 scores in std and mania, but small fruit in ctb.
+    /// Amount of 50s (droplets in ctb).
     pub count_50: u16,
-    /// Amount of gekis in std, but MAX scores (rainbow 300s) in mania.
+    /// Amount of gekis (MAX scores / rainbow 300s in mania).
     pub count_geki: u16,
-    /// Amount of katsus in std, but 100 scores in mania.
+    /// Amount of katsus (200s in mania, droplet misses in ctb).
     pub count_katsu: u16,
-    /// Amount of misses in all modes.
+    /// Amount of misses (fruit + drop misses in ctb).
     pub count_miss: u16,
     /// The numerical score achieved.
     pub score: u32,


### PR DESCRIPTION
Double whammy changes, both of which really small though.
When trying to compile without the `compression` feature it complains because it can't infer the type so this PR fixes that.
Additionally, the documentation for hitresults in `Replay` was adjusted with respect to osu!'s wiki entries.

Hope it's fine to have both in the same PR 😄 