### PR TITLE
fix(Listing): support breaking format change 20250107

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.idea


### PR DESCRIPTION
Changes star rating struct to use Int-Float pairs instead of Int-Double which heavily reduces storage size.
I didn't include a version bump in this PR but I hope you can release a version soon.

Based on the osu!.db wiki docs change: https://github.com/ppy/osu/wiki/Legacy-database-file-structure/_compare/146ec96180db7e80e3fefb9a18922aa49b12cdb7...da9169283d886241a9de121770435338800ece83